### PR TITLE
Returning status code 400 when device doesn't belong to the same company

### DIFF
--- a/MonitorWebAPI/MonitorWebAPI/Controllers/DeviceController.cs
+++ b/MonitorWebAPI/MonitorWebAPI/Controllers/DeviceController.cs
@@ -555,6 +555,11 @@ namespace MonitorWebAPI.Controllers
                                     tempDeviceGroup.GroupId = groupId;
                                     mc.SaveChanges();
                                 }
+                                else
+                                {
+
+                                    return StatusCode(400, "The device does not belong to the same company");
+                                }
 
                                 
                             }


### PR DESCRIPTION
Returning status code 400 when device doesn't belong to the same company